### PR TITLE
Fix a typographical error under "If your project is on GitHub"

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ A checklist for project owners to measure their open source project. The checkli
 ### If your project is on GitHub
 
 - [ ] Project has a short description on version control system (e.g. description on Github).
-- [ ] Releated topics are added to the repository.
+- [ ] Related topics are added to the repository.
 - [ ] Labels are used to highlight the issues ('good first issue' for beginners etc.).
 - [ ] Pull request template is created.
 - [ ] Issue template(s) is/are created.


### PR DESCRIPTION
This pull request fixes a typographical error under the "If your project is on GitHub" section.

- "Releated" should be "Related"